### PR TITLE
bugfix motor speed

### DIFF
--- a/lib/ev3/commands/output.rb
+++ b/lib/ev3/commands/output.rb
@@ -29,6 +29,7 @@ module EV3
         @message += ByteCodes::OUTPUT_SPEED.bytes +
         Layers::LAYER_0.bytes +
         [all_motors] +
+        ArgumentSize::BYTE.bytes +
         [velocity]
         return self
       end


### PR DESCRIPTION
モーターのspeedを設定する際に、引数長指定が必要だったため、追加しました。
宜しくお願いします。
